### PR TITLE
Text Replacement & Parent binding

### DIFF
--- a/lib/Component.ts
+++ b/lib/Component.ts
@@ -8,9 +8,9 @@ import EventEmitter from "eventemitter3";
 export default abstract class Component extends EventEmitter {
     private route: string;
     protected view: string;
-    protected container: string; // location where content will be rendered
+    protected container: string | JQuery; // location where content will be rendered
 
-    public constructor(route: string, container?: string) {
+    public constructor(route: string, container?: string | JQuery) {
         super();
         this.container = (container) ? container : "#root"; // default to id root
         this.route = route;

--- a/lib/DynamicComponent.ts
+++ b/lib/DynamicComponent.ts
@@ -55,7 +55,8 @@ export default abstract class DynamicComponent<P> extends Component {
                     newElement = newView.closest('[d-bind*="' + key + '"]');
                 }
                 if (oldElement[0]) {
-                    if (oldElement[0].childNodes[0]) oldElement[0].childNodes[0].nodeValue = newElement[0].childNodes[0].nodeValue;
+                    const directChild: Node = oldElement[0].childNodes[0];
+                    if (directChild && directChild.nodeValue) directChild.nodeValue = newElement[0].childNodes[0].nodeValue;
                     $.each(oldElement[0].attributes, (index, attribute) => {
                         if (newElement.attr(attribute.name)) {
                             oldElement.attr(attribute.name, newElement.attr(attribute.name));

--- a/lib/DynamicComponent.ts
+++ b/lib/DynamicComponent.ts
@@ -10,7 +10,7 @@ export default abstract class DynamicComponent<P> extends Component {
     private props: Partial<P>; // component's active state
     public context: JQuery; // self-referential location of rendered content
 
-    public constructor(route: string, container: string) {
+    public constructor(route: string, container: string|JQuery) {
         super(route, container);
         this.props = {};
     }
@@ -48,14 +48,21 @@ export default abstract class DynamicComponent<P> extends Component {
         if (this.context && $(this.container).find(this.context).length) {
             const newView = $(this.view);
             for (const key in this.props) {
-                const newElement = newView.find('[d-bind*="' + key + '"]');
-                const oldElement = this.context.find('[d-bind*="' + key + '"]');
-                oldElement.text(newElement.text());
-                $.each(oldElement[0].attributes, function(index, attribute) {
-                    if (newElement.attr(attribute.name)) {
-                        oldElement.attr(attribute.name, newElement.attr(attribute.name));
-                    }
-                });
+                let newElement = newView.find('[d-bind*="' + key + '"]');
+                let oldElement = (this.context.find('[d-bind*="' + key + '"]'));
+                if (oldElement.length === 0) {
+                    oldElement = this.context.closest('[d-bind*="' + key + '"]');
+                    newElement = newView.closest('[d-bind*="' + key + '"]');
+                }
+                if (oldElement[0]) {
+                    if (oldElement[0].childNodes[0]) oldElement[0].childNodes[0].nodeValue = newElement[0].childNodes[0].nodeValue;
+                    $.each(oldElement[0].attributes, (index, attribute) => {
+                        if (newElement.attr(attribute.name)) {
+                            oldElement.attr(attribute.name, newElement.attr(attribute.name));
+                        }
+                    });
+                }
+
             }
         } else {
             // render content normally and set context to reference its own location


### PR DESCRIPTION
Changed the text replacement to replace only on the current dom node, rather than the children. Also added a closest reference, now the top element will be considered for binding purposes. Previously you could not add d-bind and dynamic content to a top containing parent. 

