### PR TITLE
Implement per-component authentication

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 // collected export of all delta classes
-export {default as App} from "./lib/App.js";
-export {default as Component} from "./lib/Component.js";
-export {default as DynamicComponent} from "./lib/DynamicComponent.js";
+export { default as App } from "./lib/App.js";
+export { default as AppOptions } from "./lib/AppOptions.js";
+export { default as Component } from "./lib/Component.js";
+export { default as DynamicComponent } from "./lib/DynamicComponent.js";

--- a/lib/App.ts
+++ b/lib/App.ts
@@ -7,7 +7,7 @@ import Component from "./Component.js";
  * This class creates a page component for each route in the application and initializes it and all its children.
  */
 export default class App {
-    private isAuthed = false; // whether the base page was loaded with ?isAuthed
+    private isAuthorized = false; // whether the base page was loaded with ?isAuthorized
     private pages: {[route: string]: Component} = {}; // default assign so we can push to it
     private router: Navigo;
     private basePath: string; // path that prefixes all components
@@ -23,7 +23,7 @@ export default class App {
         } as AppOptions);
         this.basePath = window.location.pathname;
         this.router = new Navigo();
-        this.isAuthed = window.location.search.includes("isAuthed");
+        this.isAuthorized = window.location.search.includes("isAuthorized");
     }
 
     public async init(): Promise<void> {
@@ -43,8 +43,16 @@ export default class App {
         // universal route handler that loads content for each component
         for (const route in this.pages) {
             this.router.on(route, async (params, query) => {
-                if (this.pages[route].requiresAuth && !this.isAuthed) {
-                    return window.location.replace(this.options.auth.loginUrl + "?redirectTo=" + this.basePath + route + encodeURIComponent("?isAuthed=✓"));
+                if (this.pages[route].requiresAuth && !this.isAuthorized) {
+                    // for example, redirects browser to /login?redirectTo=/foo/bar?isAuthorized=✓
+                    // the login page should then redirect back to /foo/bar?isAuthorized=✓
+                    const urlParams = new URLSearchParams();
+                    // preserve existing GET parameters
+                    Object.keys(params || {}).forEach(k => urlParams.set(k, params[k]));
+                    // we need this for when Delta is re-loaded
+                    urlParams.set("isAuthorized", "✓");
+                    const redirectUrl = this.basePath + route + encodeURIComponent("?" + urlParams.toString());
+                    return window.location.replace(this.options.auth.loginUrl + "?redirectTo=" + redirectUrl);
                 }
                 await this.pages[route].load();
                 this.router.updatePageLinks();
@@ -52,13 +60,20 @@ export default class App {
         }
         // handle initial server-side redirection
         const urlParams = new URLSearchParams(window.location.search);
+        /*
+        Example use: you have an SPA based at /foo.
+        If you visit /foo, this logic will not be run, and isn't necessary.
+        If you visit /foo/bar, the server should redirect you to /foo?_deltaPath=/foo/bar, which will trigger this logic.
+        This logic cleans up the querystring (removes _deltaPath and the optional isAuthorized),
+            and navigates the SPA to the page in _deltaPath.
+        */
         if (urlParams.has("_deltaPath")) {
             // _deltaPath is the server-set original path (redirected from)
             const originalPath = urlParams.get("_deltaPath");
             // remove _deltaPath so we can recreate the original query string
             urlParams.delete("_deltaPath");
-            // we don't need isAuthed to be displayed to the user
-            urlParams.delete("isAuthed");
+            // we don't need isAuthorized to be displayed to the user
+            urlParams.delete("isAuthorized");
             // recreate original query string with params if necessary
             const newPath = originalPath.substring(this.basePath.length) + (urlParams.toString() ? "?" + urlParams.toString() : "");
             // re-route to the correct path

--- a/lib/App.ts
+++ b/lib/App.ts
@@ -1,5 +1,7 @@
-import Component from "./Component.js";
+import _ from "lodash";
 import Navigo from "navigo";
+import AppOptions from "./AppOptions.js";
+import Component from "./Component.js";
 
 /**
  * This class creates a page component for each route in the application and initializes it and all its children.
@@ -8,18 +10,19 @@ export default class App {
     private pages: {[route: string]: Component} = {}; // default assign so we can push to it
     private router: Navigo;
     private basePath: string; // path that prefixes all components
-    private routeSource: string; // endpoint returning a list of the app's routes
+    public readonly options: AppOptions;
 
-    public constructor(routeSource?: string) {
+    public constructor(options?: AppOptions) {
+        this.options = _.defaultsDeep(options, {
+            routeSource: "/delta/v1/routes"
+        } as AppOptions);
         this.basePath = window.location.pathname;
         this.router = new Navigo();
-        // if no route source is provided, use default endpoint in eta-web-delta module
-        this.routeSource = routeSource || "/delta/v1/routes";
     }
 
     public async init(): Promise<void> {
         // retrieve list of routes that begin with that base path
-        const data: {routes: string[]} = await $.get(this.routeSource, { basePath: this.basePath });
+        const data: {routes: string[]} = await $.get(this.options.routeSource, { basePath: this.basePath });
         // create and initialize component at each route
         await Promise.all(data.routes.map(async route => {
             try {

--- a/lib/AppOptions.ts
+++ b/lib/AppOptions.ts
@@ -1,0 +1,4 @@
+export default interface AppOptions {
+    /** endpoint returning a list of the app's routes */
+    routeSource: string;
+}

--- a/lib/AppOptions.ts
+++ b/lib/AppOptions.ts
@@ -1,4 +1,8 @@
 export default interface AppOptions {
+    auth: {
+        loginUrl: string;
+        logoutUrl: string;
+    };
     /** endpoint returning a list of the app's routes */
     routeSource: string;
 }

--- a/lib/Component.ts
+++ b/lib/Component.ts
@@ -6,6 +6,7 @@ import EventEmitter from "eventemitter3";
 */
 
 export default abstract class Component extends EventEmitter {
+    readonly requiresAuth: boolean = false;
     private route: string;
     protected view: string;
     protected container: string | JQuery; // location where content will be rendered

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,29 +5,34 @@
   "requires": true,
   "dependencies": {
     "@types/handlebars": {
-      "version": "4.0.36",
-      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.36.tgz",
-      "integrity": "sha512-LjNiTX7TY7wtuC6y3QwC93hKMuqYhgV9A1uXBKNvZtVC8ZvyWAjZkJ5BvT0K7RKqORRYRLMrqCxpw5RgS+MdrQ=="
+      "version": "4.0.37",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.37.tgz",
+      "integrity": "sha512-c/g99PQsJEFYdK3LT1qgPAZ61fu/oFOaEhov/6ZuUNMi1xQFbAOSThlX8fAQLf+QoGXtyv4S39OjIRXf3HkBtw==",
+      "dev": true
     },
     "@types/jquery": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.0.tgz",
-      "integrity": "sha512-szaKV2OQgwxYTGTY6qd9eeBfGGCaP7n2OGit4JdbOcfGgc9VWjfhMhnu5AVNhIAu8WWDIB36q9dfPVba1fGeIQ=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-N3h+rzN518yl2xKrW0o6KKdNmWZ+OwG6SoM5TBEQFF0tTv5wXPEsoOuYQ2Kt3/89XbcSZUJLdjiT/2c3BR/ApQ==",
+      "dev": true
+    },
+    "@types/lodash": {
+      "version": "4.14.108",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.108.tgz",
+      "integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA==",
+      "dev": true
     },
     "@types/navigo": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/navigo/-/navigo-7.0.0.tgz",
-      "integrity": "sha512-oEgNXMYWnjZwKpk0y9YOCuA/4BheExqNGfbTPYgW3wTps/pWWqjz6paOJ2zQ0Q2GMDDTTPPX/IcfgXTb78POZQ=="
-    },
-    "@types/node": {
-      "version": "9.4.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ=="
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@types/navigo/-/navigo-7.0.1.tgz",
+      "integrity": "sha512-auXcoS/pc39onGyf6fr2V3J3BEHUqH0a1Sa1psuGrVkCat+2D592DA7hdXY73lwCUyhGPzkf0lrcE5jH0OFeJg==",
+      "dev": true
     },
     "@types/systemjs": {
       "version": "0.20.6",
       "resolved": "https://registry.npmjs.org/@types/systemjs/-/systemjs-0.20.6.tgz",
-      "integrity": "sha512-p3yv9sBBJXi3noUG216BpUI7VtVBUAvBIfZNTiDROUY31YBfsFHM4DreS7XMekN8IjtX0ysvCnm6r3WnirnNeA=="
+      "integrity": "sha512-p3yv9sBBJXi3noUG216BpUI7VtVBUAvBIfZNTiDROUY31YBfsFHM4DreS7XMekN8IjtX0ysvCnm6r3WnirnNeA==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xroadsed/delta-client",
   "version": "0.1.7",
-  "description": "A minimal single-page application framework (specifically based on Eta).",
+  "description": "A minimal single-page application framework (specifically designed for Eta).",
   "license": "MIT",
   "main": "index.js",
   "repository": "https://github.com/crossroads-education/delta-client.git",
@@ -18,10 +18,11 @@
     "**/*.js.map",
     "**/*.ts"
   ],
-  "dependencies": {
-    "@types/handlebars": "^4.0.36",
-    "@types/jquery": "^3.3.0",
-    "@types/navigo": "^7.0.0",
+  "devDependencies": {
+    "@types/handlebars": "^4.0.37",
+    "@types/jquery": "^3.3.1",
+    "@types/lodash": "^4.14.108",
+    "@types/navigo": "^7.0.1",
     "@types/systemjs": "^0.20.6"
   }
 }


### PR DESCRIPTION
## Changes
- Refactored `App.routeSource` to `AppOptions` (for custom login/out URL support)
- Implements support for `Component.requiresAuth` (just set it to `true` in a component you want to require authentication.)

## Future Goals
- [ ] Support for permissions per-page / per-component
- [ ] Smoother handling of authentication (log in without redirecting out of SPA?)

I've made concurrent changes in eta and cre-web-delta, which are required for this PR's changes to function.